### PR TITLE
fix: skip pre-declaring outputs for extensionless target labels in srcs

### DIFF
--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -100,7 +100,14 @@ def _to_json_out(src, out_dir, root_dir):
 def _calculate_outs(srcs, to_out, *args):
     outs = []
     for src in srcs:
-        out = to_out(str(src), *args)
+        src = str(src)
+
+        # Extensionless labels are targets whose files are only known at analysis time.
+        basename = src[max(src.rfind("/"), src.rfind(":")) + 1:]
+        if "." not in basename:
+            continue
+
+        out = to_out(src, *args)
         if out:
             outs.append(out)
     return outs

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -1,8 +1,40 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//oxc:defs.bzl", "oxc_transpiler")
 
 package(default_testonly = True)
+
+# Targets carrying JsInfo are allowed in srcs; their outputs are not pre-declared.
+js_library(
+    name = "legacy_lib",
+    srcs = ["src/legacy.js"],
+)
+
+oxc_transpiler(
+    name = "transpile_target_srcs",
+    srcs = [
+        "src/main.ts",
+        "src/util.mts",
+        ":legacy_lib",
+    ],
+    out_dir = "targetsrcs",
+    root_dir = "src",
+)
+
+build_test(
+    name = "target_srcs_test",
+    targets = [
+        ":transpile_target_srcs",
+        "targetsrcs/main.js",
+    ],
+)
+
+diff_test(
+    name = "js_target_srcs_test",
+    file1 = "targetsrcs/main.js",
+    file2 = "snapshots/main.js",
+)
 
 # The "src/*.ts" glob also matches src/types.d.ts: declaration sources are
 # skipped by the rule and must not break the build or produce outputs.


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
