### PR TITLE
feat: support declaration_dir for .d.ts outputs

### DIFF
--- a/e2e/ts_project/declaration_dir/BUILD
+++ b/e2e/ts_project/declaration_dir/BUILD
@@ -1,0 +1,56 @@
+"""oxc_transpiler with a separate declaration_dir, like tsc's declarationDir.
+
+The `transpiler` writes JS to out_dir while the `declaration_transpiler`
+writes the .d.ts outputs to declaration_dir, matching the ts_project
+declaration_dir attribute.
+"""
+
+load("@aspect_rules_oxc//oxc:defs.bzl", "oxc_transpiler")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+package(default_testonly = True)
+
+ts_project(
+    name = "ts",
+    srcs = ["src/main.ts"],
+    declaration = True,
+    declaration_dir = "dist/types",
+    declaration_transpiler = partial.make(
+        oxc_transpiler,
+        declaration_dir = "dist/types",
+        emit_dts = True,
+        emit_js = False,
+        root_dir = "src",
+    ),
+    out_dir = "dist/code",
+    root_dir = "src",
+    transpiler = partial.make(
+        oxc_transpiler,
+        out_dir = "dist/code",
+        root_dir = "src",
+    ),
+    tsconfig = {},
+)
+
+build_test(
+    name = "ts_project_test",
+    targets = [
+        ":ts",
+        ":ts_types",
+    ],
+)
+
+diff_test(
+    name = "js_test",
+    file1 = "dist/code/main.js",
+    file2 = "snapshots/main.js",
+)
+
+diff_test(
+    name = "dts_test",
+    file1 = "dist/types/main.d.ts",
+    file2 = "snapshots/main.d.ts",
+)

--- a/e2e/ts_project/declaration_dir/snapshots/main.d.ts
+++ b/e2e/ts_project/declaration_dir/snapshots/main.d.ts
@@ -1,0 +1,12 @@
+export declare const greeting: string;
+export declare function add(a: number, b: number): number;
+export interface Point {
+	x: number;
+	y: number;
+}
+export declare class Vec implements Point {
+	x: number;
+	y: number;
+	constructor(x: number, y: number);
+	length(): number;
+}

--- a/e2e/ts_project/declaration_dir/snapshots/main.js
+++ b/e2e/ts_project/declaration_dir/snapshots/main.js
@@ -1,0 +1,13 @@
+export const greeting = "hello";
+export function add(a, b) {
+	return a + b;
+}
+export class Vec {
+	constructor(x, y) {
+		this.x = x;
+		this.y = y;
+	}
+	length() {
+		return Math.sqrt(this.x * this.x + this.y * this.y);
+	}
+}

--- a/e2e/ts_project/declaration_dir/src/main.ts
+++ b/e2e/ts_project/declaration_dir/src/main.ts
@@ -1,0 +1,21 @@
+export const greeting: string = "hello";
+
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export class Vec implements Point {
+  constructor(
+    public x: number,
+    public y: number,
+  ) {}
+
+  length(): number {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  }
+}

--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -63,7 +63,7 @@ def _to_js_out(src, out_dir, root_dir):
         )
     return out
 
-def _to_dts_out(src, out_dir, root_dir):
+def _to_dts_out(src, declaration_dir, root_dir):
     """Return the declaration output path for a source path, or None to skip it."""
     path = src[src.find(":") + 1:]
 
@@ -78,7 +78,7 @@ def _to_dts_out(src, out_dir, root_dir):
         return None
 
     out_ext = _DTS_EXT_MAP.get(src_ext, ".d.ts")
-    return _out_path(path[:ext_idx] + out_ext, out_dir, root_dir)
+    return _out_path(path[:ext_idx] + out_ext, declaration_dir, root_dir)
 
 def _to_json_out(src, out_dir, root_dir):
     """Return the output path for a `.json` source, or None to skip it."""
@@ -161,6 +161,11 @@ def _oxc_transpiler_impl(ctx):
     if ctx.attr.out_dir != "" and ctx.attr.root_dir == "":
         fail("When out_dir is set, root_dir must also be set.")
 
+    if ctx.attr.declaration_dir != "" and ctx.attr.root_dir == "":
+        fail("When declaration_dir is set, root_dir must also be set.")
+
+    declaration_dir = ctx.attr.declaration_dir or ctx.attr.out_dir
+
     root_dir = ctx.attr.root_dir.removesuffix("/")
     if root_dir == ".":
         root_dir = ""
@@ -222,7 +227,7 @@ def _oxc_transpiler_impl(ctx):
                 transpile_dts_outs.append(None)
             else:
                 out_path = src_path[:ext_idx] + _DTS_EXT_MAP.get(src_ext, ".d.ts")
-                out_path = lib.to_out_path(out_path, ctx.attr.out_dir, ctx.attr.root_dir)
+                out_path = lib.to_out_path(out_path, declaration_dir, ctx.attr.root_dir)
                 out = _declare(ctx, predeclared, out_path)
                 dts_outs.append(out)
                 transpile_dts_outs.append(out)
@@ -287,6 +292,10 @@ _oxc_transpiler_rule = rule(
         "dts_outs": attr.output_list(),
         "json_outs": attr.output_list(),
         "out_dir": attr.string(),
+        "declaration_dir": attr.string(
+            doc = "Directory for the .d.ts outputs, like tsc's declarationDir. " +
+                  "Defaults to out_dir.",
+        ),
         "root_dir": attr.string(),
         "emit_js": attr.bool(
             default = True,
@@ -322,6 +331,7 @@ def oxc_transpiler(
         name,
         srcs,
         out_dir = "",
+        declaration_dir = "",
         root_dir = "",
         emit_js = True,
         emit_dts = False,
@@ -333,9 +343,10 @@ def oxc_transpiler(
         name = name,
         srcs = srcs,
         js_outs = _calculate_outs(srcs, _to_js_out, out_dir or "", root_dir or "") if emit_js else [],
-        dts_outs = _calculate_outs(srcs, _to_dts_out, out_dir or "", root_dir or "") if emit_dts else [],
+        dts_outs = _calculate_outs(srcs, _to_dts_out, declaration_dir or out_dir or "", root_dir or "") if emit_dts else [],
         json_outs = _calculate_outs(srcs, _to_json_out, out_dir or "", root_dir or "") if emit_js else [],
         out_dir = out_dir or "",
+        declaration_dir = declaration_dir or "",
         root_dir = root_dir or "",
         emit_js = emit_js,
         emit_dts = emit_dts,

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -300,3 +300,91 @@ diff_test(
     file1 = "dtsonly/main.d.ts",
     file2 = "snapshots/main.d.ts",
 )
+
+# declaration_dir: declarations are written to their own directory, like tsc's declarationDir,
+# while JS outputs stay in out_dir.
+oxc_transpiler(
+    name = "transpile_declaration_dir",
+    srcs = [
+        "src/main.ts",
+        "src/util.mts",
+    ],
+    declaration_dir = "ddir/types",
+    emit_dts = True,
+    out_dir = "ddir/code",
+    root_dir = "src",
+)
+
+build_test(
+    name = "declaration_dir_outputs_test",
+    targets = [
+        "ddir/code/main.js",
+        "ddir/code/util.mjs",
+        "ddir/types/main.d.ts",
+        "ddir/types/util.d.mts",
+    ],
+)
+
+diff_test(
+    name = "js_declaration_dir_test",
+    file1 = "ddir/code/main.js",
+    file2 = "snapshots/main.js",
+)
+
+diff_test(
+    name = "dts_declaration_dir_test",
+    file1 = "ddir/types/main.d.ts",
+    file2 = "snapshots/main.d.ts",
+)
+
+diff_test(
+    name = "dts_declaration_dir_mts_test",
+    file1 = "ddir/types/util.d.mts",
+    file2 = "snapshots/util.d.mts",
+)
+
+# declaration_dir without out_dir: JS lands at the package root (root_dir stripped), declarations
+# under declaration_dir.
+oxc_transpiler(
+    name = "transpile_declaration_dir_only",
+    srcs = ["src/util.mts"],
+    declaration_dir = "ddtypes",
+    emit_dts = True,
+    root_dir = "src",
+)
+
+build_test(
+    name = "declaration_dir_only_outputs_test",
+    targets = [
+        "util.mjs",
+        "ddtypes/util.d.mts",
+    ],
+)
+
+diff_test(
+    name = "js_declaration_dir_only_test",
+    file1 = "util.mjs",
+    file2 = "snapshots/util.mjs",
+)
+
+diff_test(
+    name = "dts_declaration_dir_only_test",
+    file1 = "ddtypes/util.d.mts",
+    file2 = "snapshots/util.d.mts",
+)
+
+# declaration_dir with emit_js = False: only the declarations, in their own directory.
+oxc_transpiler(
+    name = "transpile_declaration_dir_dts_only",
+    srcs = ["src/main.ts"],
+    declaration_dir = "onlytypes",
+    emit_dts = True,
+    emit_js = False,
+    root_dir = "src",
+)
+
+diff_test(
+    name = "dts_declaration_dir_dts_only_test",
+    file1 = "onlytypes/main.d.ts",
+    file2 = "snapshots/main.d.ts",
+)


### PR DESCRIPTION
Adds a declaration_dir attribute to oxc_transpiler, mirroring tsc's declarationDir: declaration outputs are written under declaration_dir while JS outputs stay in out_dir. Defaults to out_dir. Like out_dir, it requires root_dir to be set.

Covered by rule-level tests (with and without out_dir, and with emit_js = False) and an e2e ts_project example wiring declaration_dir through the transpiler/declaration_transpiler attributes.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
