### PR TITLE
chore: update transpiler prebuilt sha256s for v0.0.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,25 +28,25 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = Tr
 # happens in //oxc/private:transpiler.
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-TRANSPILER_VERSION = "0.0.4"
+TRANSPILER_VERSION = "0.0.5"
 
 http_file(
     name = "transpiler_aarch64_apple_darwin",
     executable = True,
-    sha256 = "d7706bada72511e6fbfd6066b51646b15ae22f763f189444a9f2bad0464226f5",
+    sha256 = "70a06b871490bdba6e1833512c20eb026c9c05430511f55b60212a7acdaeedad",
     url = "https://github.com/aspect-build/rules_oxc/releases/download/transpiler-v" + TRANSPILER_VERSION + "/transpiler-aarch64-apple-darwin",
 )
 
 http_file(
     name = "transpiler_aarch64_unknown_linux_gnu",
     executable = True,
-    sha256 = "a9fa9f9fe58861e1fd9aa663f3ac461352edbc9b573b2242ba28ec9d745027fc",
+    sha256 = "08fd0d37cf680c30a633162ab7a63fca89a81462baaaad011016b34648576107",
     url = "https://github.com/aspect-build/rules_oxc/releases/download/transpiler-v" + TRANSPILER_VERSION + "/transpiler-aarch64-unknown-linux-gnu",
 )
 
 http_file(
     name = "transpiler_x86_64_unknown_linux_gnu",
     executable = True,
-    sha256 = "db3a4005fecfcbea61e965f42f33d550beafb813595b4e123c2e5effc92145f2",
+    sha256 = "c6ad934bf291fe53d192cfc3747312f631937a303507f47f23c74e4d6a2bca88",
     url = "https://github.com/aspect-build/rules_oxc/releases/download/transpiler-v" + TRANSPILER_VERSION + "/transpiler-x86_64-unknown-linux-gnu",
 )


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
