### PR TITLE
feat: support downleveling JS outputs with a target attribute

### DIFF
--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -140,6 +140,8 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--source-maps")
         if ctx.attr.rewrite_extensions:
             args.add("--rewrite-extensions")
+        if ctx.attr.target:
+            args.add("--target", ctx.attr.target)
     if emit_dts:
         args.add("--emit-dts")
     args.add("--manifest")
@@ -309,6 +311,32 @@ _oxc_transpiler_rule = rule(
             default = False,
             doc = "Emit a .js.map source map file alongside each JS output.",
         ),
+        "target": attr.string(
+            doc = "Downlevel the JS outputs to an ECMAScript target (e.g. " +
+                  "\"es2017\"), like tsc's target. Defaults to the latest ES " +
+                  "version: syntax is left as written. es5 is not allowed: oxc " +
+                  "cannot fully downlevel ES2015 syntax. Transforms that need a " +
+                  "runtime helper (e.g. async functions below es2017) import it " +
+                  "from @oxc-project/runtime, which must then be added as a " +
+                  "runtime dependency. Declaration outputs are unaffected.",
+            values = [
+                "",
+                "es6",
+                "es2015",
+                "es2016",
+                "es2017",
+                "es2018",
+                "es2019",
+                "es2020",
+                "es2021",
+                "es2022",
+                "es2023",
+                "es2024",
+                "es2025",
+                "es2026",
+                "esnext",
+            ],
+        ),
         "rewrite_extensions": attr.bool(
             default = False,
             doc = "Rewrite import/export specifiers that end in '.ts', '.tsx', " +
@@ -337,6 +365,7 @@ def oxc_transpiler(
         emit_dts = False,
         source_maps = False,
         rewrite_extensions = False,
+        target = "",
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time."""
     _oxc_transpiler_rule(
@@ -352,5 +381,6 @@ def oxc_transpiler(
         emit_dts = emit_dts,
         source_maps = source_maps or False,
         rewrite_extensions = rewrite_extensions or False,
+        target = target or "",
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -388,3 +388,36 @@ diff_test(
     file1 = "onlytypes/main.d.ts",
     file2 = "snapshots/main.d.ts",
 )
+
+# target: downlevel JS outputs like tsc's target. es2015 transforms the exponent operator,
+# optional chaining, and async functions; downleveled async imports the asyncToGenerator helper
+# from @oxc-project/runtime.
+oxc_transpiler(
+    name = "transpile_target_es2015",
+    srcs = ["src/modern.ts"],
+    out_dir = "targetes2015",
+    root_dir = "src",
+    target = "es2015",
+)
+
+diff_test(
+    name = "target_es2015_test",
+    file1 = "targetes2015/modern.js",
+    file2 = "snapshots/modern_es2015.js",
+)
+
+# es2019 only downlevels features newer than it: optional chaining and nullish coalescing are
+# transformed, exponent and async are kept.
+oxc_transpiler(
+    name = "transpile_target_es2019",
+    srcs = ["src/modern.ts"],
+    out_dir = "targetes2019",
+    root_dir = "src",
+    target = "es2019",
+)
+
+diff_test(
+    name = "target_es2019_test",
+    file1 = "targetes2019/modern.js",
+    file2 = "snapshots/modern_es2019.js",
+)

--- a/oxc/tests/snapshots/modern_es2015.js
+++ b/oxc/tests/snapshots/modern_es2015.js
@@ -1,0 +1,15 @@
+import _asyncToGenerator from "@oxc-project/runtime/helpers/asyncToGenerator";
+export const big = Math.pow(2, 10);
+export function fetchValue() {
+	return _fetchValue.apply(this, arguments);
+}
+function _fetchValue() {
+	_fetchValue = _asyncToGenerator(function* () {
+		return big;
+	});
+	return _fetchValue.apply(this, arguments);
+}
+export function pick(input) {
+	var _input$nested$value, _input$nested;
+	return (_input$nested$value = (_input$nested = input.nested) === null || _input$nested === void 0 ? void 0 : _input$nested.value) !== null && _input$nested$value !== void 0 ? _input$nested$value : 0;
+}

--- a/oxc/tests/snapshots/modern_es2019.js
+++ b/oxc/tests/snapshots/modern_es2019.js
@@ -1,0 +1,8 @@
+export const big = 2 ** 10;
+export async function fetchValue() {
+	return big;
+}
+export function pick(input) {
+	var _input$nested$value, _input$nested;
+	return (_input$nested$value = (_input$nested = input.nested) === null || _input$nested === void 0 ? void 0 : _input$nested.value) !== null && _input$nested$value !== void 0 ? _input$nested$value : 0;
+}

--- a/oxc/tests/src/modern.ts
+++ b/oxc/tests/src/modern.ts
@@ -1,0 +1,9 @@
+export const big: number = 2 ** 10;
+
+export async function fetchValue(): Promise<number> {
+  return big;
+}
+
+export function pick(input: { nested?: { value?: number } }): number {
+  return input.nested?.value ?? 0;
+}


### PR DESCRIPTION
Adds a target attribute to oxc_transpiler, passed to the transpiler as --target: the value (e.g. "es2017") downlevels JS outputs like tsc's target. Unset leaves syntax at the latest ES version, as before.

Transforms that need a runtime helper import it from @oxc-project/runtime, which must then be a runtime dependency; the attribute documentation calls this out.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
