### PR TITLE
feat: support module formats with a module attribute

### DIFF
--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -144,6 +144,8 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--rewrite-extensions")
         if ctx.attr.target:
             args.add("--target", ctx.attr.target)
+        if ctx.attr.module:
+            args.add("--module", ctx.attr.module)
         if ctx.attr.helpers_module:
             args.add("--helpers-module", ctx.attr.helpers_module)
     if emit_dts:
@@ -358,6 +360,21 @@ _oxc_transpiler_rule = rule(
                   "tsc's jsx value spellings to oxc's manually.",
             values = ["", "automatic", "classic"],
         ),
+        "module": attr.string(
+            doc = "Module format of the JS outputs, using oxc's module values. " +
+                  "\"preserve\" (default) keeps the input module syntax. " +
+                  "\"esm\" keeps ESM syntax and makes TypeScript's " +
+                  "CommonJS-specific syntax (`export =`, `import x = " +
+                  "require(...)`) an error; tsc spells this mode " +
+                  "es2015/esnext, so map your tsconfig module manually. " +
+                  "\"commonjs\" mirrors tsc's module=commonjs for that " +
+                  "CommonJS-specific syntax: `export =` becomes " +
+                  "`module.exports =`, `import x = require(...)` becomes a " +
+                  "require call, and a \"use strict\" directive is added. oxc " +
+                  "has no ESM-to-CommonJS transform, so ESM import/export " +
+                  "syntax in the sources is an error with \"commonjs\".",
+            values = ["", "preserve", "esm", "commonjs"],
+        ),
         "rewrite_extensions": attr.bool(
             default = False,
             doc = "Rewrite import/export specifiers that end in '.ts', '.tsx', " +
@@ -389,6 +406,7 @@ def oxc_transpiler(
         target = "",
         helpers_module = "",
         jsx = "",
+        module = "",
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time."""
     _oxc_transpiler_rule(
@@ -407,5 +425,6 @@ def oxc_transpiler(
         rewrite_extensions = rewrite_extensions or False,
         target = target or "",
         helpers_module = helpers_module or "",
+        module = module or "",
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -503,3 +503,37 @@ diff_test(
     file1 = "helperscustom/helpersfx/async.js",
     file2 = "snapshots/async_custom_helpers.js",
 )
+
+# module = "commonjs": TypeScript's CommonJS-specific syntax is rewritten (`export =` to
+# module.exports, `import x = require(...)` to a require call) and "use strict" is added. ESM
+# syntax in srcs would be an error: oxc has no ESM-to-CommonJS transform.
+oxc_transpiler(
+    name = "transpile_module_commonjs",
+    srcs = ["src/module_commonjs/api.cts"],
+    module = "commonjs",
+    out_dir = "cjs",
+    root_dir = "src",
+)
+
+diff_test(
+    name = "module_commonjs_test",
+    file1 = "cjs/module_commonjs/api.cjs",
+    file2 = "snapshots/api.cjs",
+)
+
+# module = "esm": ESM syntax passes through unchanged (same output as "preserve" for ESM
+# sources); TypeScript's CommonJS-specific syntax would be an error instead of being rewritten.
+# tsc spells this mode es2015/esnext; the oxc value is used here.
+oxc_transpiler(
+    name = "transpile_module_esm",
+    srcs = ["src/main.ts"],
+    module = "esm",
+    out_dir = "esmout",
+    root_dir = "src",
+)
+
+diff_test(
+    name = "module_esm_test",
+    file1 = "esmout/main.js",
+    file2 = "snapshots/main.js",
+)

--- a/oxc/tests/snapshots/api.cjs
+++ b/oxc/tests/snapshots/api.cjs
@@ -1,0 +1,7 @@
+"use strict";
+const path = require("node:path");
+const answer = 42;
+module.exports = {
+	answer,
+	sep: path.sep
+};

--- a/oxc/tests/src/module_commonjs/api.cts
+++ b/oxc/tests/src/module_commonjs/api.cts
@@ -1,0 +1,5 @@
+import path = require("node:path");
+
+const answer: number = 42;
+
+export = { answer, sep: path.sep };


### PR DESCRIPTION
Adds a module attribute to oxc_transpiler with oxc's module values "preserve" (default), "esm", and "commonjs", passed to the transpiler as --module.

"commonjs" rewrites TypeScript's CommonJS-specific syntax (`export =`, `import x = require(...)`) and adds "use strict"; ESM syntax in srcs is an error since oxc has no ESM-to-CommonJS transform. "esm" keeps ESM syntax and makes that CommonJS-specific syntax an error instead. tsc spells the esm mode es2015/esnext; the oxc value is used here and users map their tsconfig module manually.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
