### PR TITLE
feat: support rootDirs-style virtual directories with root_dirs

### DIFF
--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -114,12 +114,16 @@ def _declare(ctx, predeclared, out_path):
         out = ctx.actions.declare_file(out_path)
     return out
 
-def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
+def _run_transpile(ctx, srcs, declaration_srcs, js_outs, dts_outs, map_outs):
     """Run one transpiler action emitting JS and/or declaration outputs.
 
     Each manifest entry is the source path followed by its JS output path
     (when emitting JS) and its declaration output path (when emitting dts).
     A dts entry may be None (plain JS sources), written as an empty line.
+
+    declaration_srcs are .d.ts sources that produce no outputs but are staged
+    as action inputs so relative import resolution (including across
+    root_dirs) can see them on disk.
     """
     emit_dts = ctx.attr.emit_dts and any(dts_outs)
 
@@ -148,13 +152,21 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--module", ctx.attr.module)
         if ctx.attr.helpers_module:
             args.add("--helpers-module", ctx.attr.helpers_module)
+        prefix = ctx.label.package + "/" if ctx.label.package else ""
+        for root in ctx.attr.root_dirs:
+            args.add("--root-dirs", prefix + root)
+
+            # Generated srcs live under the output tree, so each root is also passed at its
+            # bin-dir path; the resolver's longest-prefix match then covers importers and
+            # import targets on either side.
+            args.add("--root-dirs", ctx.bin_dir.path + "/" + prefix + root)
     if emit_dts:
         args.add("--emit-dts")
     args.add("--manifest")
     args.add(manifest)
 
     ctx.actions.run(
-        inputs = srcs + [manifest],
+        inputs = srcs + declaration_srcs + [manifest],
         arguments = [args],
         mnemonic = "OxcTranspile",
         executable = ctx.executable._tool,
@@ -184,6 +196,7 @@ def _oxc_transpiler_impl(ctx):
     dts_outs = []  # declaration files only, for JsInfo types
     json_outs = []  # data files copied through unchanged, alongside JS outputs
     transpile_srcs = []
+    declaration_srcs = []  # .d.ts sources: no outputs, staged for resolution
     transpile_js_outs = []  # aligned with transpile_srcs
     transpile_dts_outs = []  # aligned with transpile_srcs
     map_outs = []
@@ -192,6 +205,7 @@ def _oxc_transpiler_impl(ctx):
 
     for src, src_path in zip(ctx.files.srcs, src_paths):
         if _is_declaration(src_path):
+            declaration_srcs.append(src)
             continue
 
         if root_dir != "" and not src_path.startswith(root_dir + "/"):
@@ -241,7 +255,7 @@ def _oxc_transpiler_impl(ctx):
                 transpile_dts_outs.append(out)
 
     if transpile_srcs:
-        _run_transpile(ctx, transpile_srcs, transpile_js_outs, transpile_dts_outs, map_outs)
+        _run_transpile(ctx, transpile_srcs, declaration_srcs, transpile_js_outs, transpile_dts_outs, map_outs)
 
     # Mirror the ts_project provider shape: source maps count as sources,
     # DefaultInfo falls back to types when no JS is emitted, declarations are
@@ -305,6 +319,16 @@ _oxc_transpiler_rule = rule(
                   "Defaults to out_dir.",
         ),
         "root_dir": attr.string(),
+        "root_dirs": attr.string_list(
+            doc = "Package-relative directories overlaid into one virtual " +
+                  "directory when resolving relative imports, like tsc's " +
+                  "rootDirs. An extensionless relative import that does not " +
+                  "resolve next to its source is looked up at the same " +
+                  "relative location under the other root_dirs (declaration " +
+                  "sources included) to pick the emitted JS extension; the " +
+                  "specifier text is otherwise left unchanged, so the files " +
+                  "must be merged into one directory at runtime.",
+        ),
         "emit_js": attr.bool(
             default = True,
             doc = "Emit JavaScript outputs.",
@@ -407,6 +431,7 @@ def oxc_transpiler(
         helpers_module = "",
         jsx = "",
         module = "",
+        root_dirs = [],
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time."""
     _oxc_transpiler_rule(
@@ -426,5 +451,6 @@ def oxc_transpiler(
         target = target or "",
         helpers_module = helpers_module or "",
         module = module or "",
+        root_dirs = root_dirs or [],
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -537,3 +537,59 @@ diff_test(
     file1 = "esmout/main.js",
     file2 = "snapshots/main.js",
 )
+
+# Generated sources land under the output tree; the rule maps each root to its bin-dir path too,
+# so they participate in root_dirs resolution.
+genrule(
+    name = "genmod_ts",
+    outs = ["src/virtual/genr/genmod.ts"],
+    cmd = "echo 'export const generated: number = 4;' > $@",
+)
+
+# root_dirs: like tsc's rootDirs, app, lib, and the generated genr root form one virtual
+# directory for resolving relative imports. main.ts resolves "./local" beside itself, "./shared"
+# from the lib root, "./gen" from a declaration-only source in the lib root, and "./genmod" from
+# a generated source in the genr root.
+oxc_transpiler(
+    name = "transpile_root_dirs",
+    srcs = [
+        "src/virtual/app/local.ts",
+        "src/virtual/app/main.ts",
+        "src/virtual/lib/gen.d.ts",
+        "src/virtual/lib/shared.ts",
+        ":genmod_ts",
+    ],
+    out_dir = "virtualout",
+    root_dir = "src/virtual",
+    root_dirs = [
+        "src/virtual/app",
+        "src/virtual/lib",
+        "src/virtual/genr",
+    ],
+)
+
+diff_test(
+    name = "root_dirs_main_test",
+    file1 = "virtualout/app/main.js",
+    file2 = "snapshots/main_root_dirs.js",
+)
+
+# Without root_dirs the same sources fail to resolve "./shared", "./gen", and "./genmod":
+# specifiers are left extensionless, matching the previous behavior.
+oxc_transpiler(
+    name = "transpile_root_dirs_off",
+    srcs = [
+        "src/virtual/app/local.ts",
+        "src/virtual/app/main.ts",
+        "src/virtual/lib/gen.d.ts",
+        "src/virtual/lib/shared.ts",
+    ],
+    out_dir = "virtualoff",
+    root_dir = "src/virtual",
+)
+
+diff_test(
+    name = "root_dirs_off_main_test",
+    file1 = "virtualoff/app/main.js",
+    file2 = "snapshots/main_root_dirs_off.js",
+)

--- a/oxc/tests/snapshots/main_root_dirs.js
+++ b/oxc/tests/snapshots/main_root_dirs.js
@@ -1,0 +1,5 @@
+import { local } from "./local.js";
+import { shared } from "./shared.js";
+import { answer } from "./gen.js";
+import { generated } from "./genmod.js";
+export const total = local + shared + answer + generated;

--- a/oxc/tests/snapshots/main_root_dirs_off.js
+++ b/oxc/tests/snapshots/main_root_dirs_off.js
@@ -1,0 +1,5 @@
+import { local } from "./local.js";
+import { shared } from "./shared";
+import { answer } from "./gen";
+import { generated } from "./genmod";
+export const total = local + shared + answer + generated;

--- a/oxc/tests/src/virtual/app/local.ts
+++ b/oxc/tests/src/virtual/app/local.ts
@@ -1,0 +1,1 @@
+export const local: number = 1;

--- a/oxc/tests/src/virtual/app/main.ts
+++ b/oxc/tests/src/virtual/app/main.ts
@@ -1,0 +1,6 @@
+import { local } from "./local";
+import { shared } from "./shared";
+import { answer } from "./gen";
+import { generated } from "./genmod";
+
+export const total: number = local + shared + answer + generated;

--- a/oxc/tests/src/virtual/lib/gen.d.ts
+++ b/oxc/tests/src/virtual/lib/gen.d.ts
@@ -1,0 +1,1 @@
+export declare const answer: number;

--- a/oxc/tests/src/virtual/lib/shared.ts
+++ b/oxc/tests/src/virtual/lib/shared.ts
@@ -1,0 +1,1 @@
+export const shared: number = 2;


### PR DESCRIPTION
Adds a root_dirs attribute to oxc_transpiler, passed to the transpiler as repeated --root-dirs flags with the package path prefixed: the listed package-relative directories are overlaid into one virtual directory when resolving extensionless relative imports, like tsc's rootDirs. The specifier text is unchanged, so the files must be merged into one directory at runtime.

Declaration sources now participate: .d.ts files in srcs are staged as action inputs (still producing no outputs) so resolution can see them, letting a declaration-only target like gen.d.ts resolve "./gen" to "./gen.js".

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
