### PR TITLE
feat: support redirecting runtime helper imports with helpers_module

### DIFF
--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -142,6 +142,8 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--rewrite-extensions")
         if ctx.attr.target:
             args.add("--target", ctx.attr.target)
+        if ctx.attr.helpers_module:
+            args.add("--helpers-module", ctx.attr.helpers_module)
     if emit_dts:
         args.add("--emit-dts")
     args.add("--manifest")
@@ -337,6 +339,15 @@ _oxc_transpiler_rule = rule(
                 "esnext",
             ],
         ),
+        "helpers_module": attr.string(
+            doc = "Module to import runtime helpers from, defaulting to " +
+                  "@oxc-project/runtime. Transforms that need a helper always " +
+                  "import it, like tsc's importHelpers; oxc has no inline " +
+                  "helper mode, so tsc's default importHelpers=false behavior " +
+                  "cannot be reproduced. The helpers module must be a runtime " +
+                  "dependency whenever a transform emits helper imports (none " +
+                  "do in the default configuration).",
+        ),
         "rewrite_extensions": attr.bool(
             default = False,
             doc = "Rewrite import/export specifiers that end in '.ts', '.tsx', " +
@@ -366,6 +377,7 @@ def oxc_transpiler(
         source_maps = False,
         rewrite_extensions = False,
         target = "",
+        helpers_module = "",
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time."""
     _oxc_transpiler_rule(
@@ -382,5 +394,6 @@ def oxc_transpiler(
         source_maps = source_maps or False,
         rewrite_extensions = rewrite_extensions or False,
         target = target or "",
+        helpers_module = helpers_module or "",
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -421,3 +421,69 @@ diff_test(
     file1 = "targetes2019/modern.js",
     file2 = "snapshots/modern_es2019.js",
 )
+
+# helpers_module unset: no --helpers-module is passed, deferring the default entirely to the
+# tool (oxc's @oxc-project/runtime); the emitted module name is covered by the transpiler's
+# helpers_imported_from_default_module unit test, since no transform in the rule's default
+# configuration needs a helper.
+oxc_transpiler(
+    name = "transpile_helpers_default",
+    srcs = ["src/main.ts"],
+    out_dir = "helpersdefault",
+    root_dir = "src",
+)
+
+diff_test(
+    name = "helpers_default_test",
+    file1 = "helpersdefault/main.js",
+    file2 = "snapshots/main.js",
+)
+
+# helpers_module set but unused: with no helper-requiring transform the redirected module leaves
+# no trace, so the output is byte-identical to the plain snapshot ("custom-helpers" appears
+# nowhere). The redirect itself is covered by the transpiler's unit tests.
+oxc_transpiler(
+    name = "transpile_helpers_module_unused",
+    srcs = ["src/main.ts"],
+    helpers_module = "custom-helpers",
+    out_dir = "helpers",
+    root_dir = "src",
+)
+
+diff_test(
+    name = "helpers_module_unused_test",
+    file1 = "helpers/main.js",
+    file2 = "snapshots/main.js",
+)
+
+# Downleveling async below es2017 needs the asyncToGenerator helper: with helpers_module unset
+# it is imported from the tool's default, @oxc-project/runtime.
+oxc_transpiler(
+    name = "transpile_helpers_default_downlevel",
+    srcs = ["src/helpersfx/async.ts"],
+    out_dir = "helpersdl",
+    root_dir = "src",
+    target = "es2016",
+)
+
+diff_test(
+    name = "helpers_default_downlevel_test",
+    file1 = "helpersdl/helpersfx/async.js",
+    file2 = "snapshots/async_default_helpers.js",
+)
+
+# The same helper import, redirected by helpers_module.
+oxc_transpiler(
+    name = "transpile_helpers_module_downlevel",
+    srcs = ["src/helpersfx/async.ts"],
+    helpers_module = "custom-helpers",
+    out_dir = "helperscustom",
+    root_dir = "src",
+    target = "es2016",
+)
+
+diff_test(
+    name = "helpers_module_downlevel_test",
+    file1 = "helperscustom/helpersfx/async.js",
+    file2 = "snapshots/async_custom_helpers.js",
+)

--- a/oxc/tests/snapshots/async_custom_helpers.js
+++ b/oxc/tests/snapshots/async_custom_helpers.js
@@ -1,0 +1,10 @@
+import _asyncToGenerator from "custom-helpers/helpers/asyncToGenerator";
+export function fetchOne() {
+	return _fetchOne.apply(this, arguments);
+}
+function _fetchOne() {
+	_fetchOne = _asyncToGenerator(function* () {
+		return 1;
+	});
+	return _fetchOne.apply(this, arguments);
+}

--- a/oxc/tests/snapshots/async_default_helpers.js
+++ b/oxc/tests/snapshots/async_default_helpers.js
@@ -1,0 +1,10 @@
+import _asyncToGenerator from "@oxc-project/runtime/helpers/asyncToGenerator";
+export function fetchOne() {
+	return _fetchOne.apply(this, arguments);
+}
+function _fetchOne() {
+	_fetchOne = _asyncToGenerator(function* () {
+		return 1;
+	});
+	return _fetchOne.apply(this, arguments);
+}

--- a/oxc/tests/src/helpersfx/async.ts
+++ b/oxc/tests/src/helpersfx/async.ts
@@ -1,0 +1,3 @@
+export async function fetchOne(): Promise<number> {
+  return 1;
+}


### PR DESCRIPTION
Adds a helpers_module attribute to oxc_transpiler, passed to the transpiler as --helpers-module: transforms that need a runtime helper import it from this module instead of the default @oxc-project/runtime. The helpers module must be a runtime dependency whenever a transform emits helper imports; none do in the default configuration.

Covered by a rule-level test that the attribute is plumbed through and default output is unaffected; the redirect itself is covered by the transpiler's unit tests.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
