### PR TITLE
feat: add strip_internal

### DIFF
--- a/e2e/ts_project/README.md
+++ b/e2e/ts_project/README.md
@@ -25,6 +25,8 @@ and `declaration_transpiler` attributes, one configuration per subdirectory:
   mirrored by `use_define_for_class_fields = False`.
 - `verbatim_module_syntax` - tsconfig `verbatimModuleSyntax` mirrored by
   `verbatim_module_syntax`, keeping imports unused after type stripping.
+- `strip_internal` - tsconfig `stripInternal` mirrored by `strip_internal`,
+  omitting `@internal` declarations from the shared transpile target's `.d.ts`.
 
 It lives as a separate e2e workspace because `ts_project` requires the
 `@npm_typescript` repository and node toolchain setup that the aspect_rules_oxc

--- a/e2e/ts_project/strip_internal/BUILD
+++ b/e2e/ts_project/strip_internal/BUILD
@@ -1,0 +1,55 @@
+"""oxc_transpiler omitting @internal declarations, matching tsconfig stripInternal.
+
+The single shared transpile target emits both outputs; strip_internal only
+affects the .d.ts, dropping declarations documented with `/** @internal */`.
+"""
+
+load("@aspect_rules_oxc//oxc:defs.bzl", "oxc_transpiler")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("//:single_transpiler.bzl", "oxc_transpiler_declarations")
+
+package(default_testonly = True)
+
+ts_project(
+    name = "ts",
+    srcs = ["src/main.ts"],
+    declaration = True,
+    declaration_transpiler = oxc_transpiler_declarations,
+    out_dir = "dist",
+    root_dir = "src",
+    transpiler = partial.make(
+        oxc_transpiler,
+        emit_dts = True,
+        out_dir = "dist",
+        root_dir = "src",
+        strip_internal = True,
+    ),
+    tsconfig = {
+        "compilerOptions": {
+            "stripInternal": True,
+        },
+    },
+)
+
+build_test(
+    name = "ts_project_test",
+    targets = [
+        ":ts",
+        ":ts_types",
+    ],
+)
+
+diff_test(
+    name = "js_test",
+    file1 = "dist/main.js",
+    file2 = "snapshots/main.js",
+)
+
+diff_test(
+    name = "dts_test",
+    file1 = "dist/main.d.ts",
+    file2 = "snapshots/main.d.ts",
+)

--- a/e2e/ts_project/strip_internal/snapshots/main.d.ts
+++ b/e2e/ts_project/strip_internal/snapshots/main.d.ts
@@ -1,0 +1,4 @@
+export declare const visible: number;
+export declare class Api {
+	shown(): void;
+}

--- a/e2e/ts_project/strip_internal/snapshots/main.js
+++ b/e2e/ts_project/strip_internal/snapshots/main.js
@@ -1,0 +1,8 @@
+/** @internal */
+export const secret = 1;
+export const visible = 2;
+export class Api {
+	/** @internal */
+	hidden() {}
+	shown() {}
+}

--- a/e2e/ts_project/strip_internal/src/main.ts
+++ b/e2e/ts_project/strip_internal/src/main.ts
@@ -1,0 +1,11 @@
+/** @internal */
+export const secret: number = 1;
+
+export const visible: number = 2;
+
+export class Api {
+  /** @internal */
+  hidden(): void {}
+
+  shown(): void {}
+}

--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -170,6 +170,8 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--only-remove-type-imports")
     if emit_dts:
         args.add("--emit-dts")
+        if ctx.attr.strip_internal:
+            args.add("--strip-internal")
     args.add("--manifest")
     args.add(manifest)
 
@@ -410,6 +412,12 @@ _oxc_transpiler_rule = rule(
                   "Declaration outputs are unaffected.",
             values = ["", "true", "false"],
         ),
+        "strip_internal": attr.bool(
+            default = False,
+            doc = "tsc's stripInternal: omit declarations documented with " +
+                  "`/** @internal */` from the .d.ts outputs. JS outputs are " +
+                  "unaffected.",
+        ),
         "verbatim_module_syntax": attr.bool(
             default = False,
             doc = "tsc's verbatimModuleSyntax: only imports and exports " +
@@ -470,6 +478,7 @@ def oxc_transpiler(
         helpers_module = "",
         use_define_for_class_fields = None,
         verbatim_module_syntax = False,
+        strip_internal = False,
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time.
 
@@ -493,6 +502,8 @@ def oxc_transpiler(
             A select() must use the strings "true" and "false".
         verbatim_module_syntax: tsc's verbatimModuleSyntax; keep imports that are unused
             after type stripping instead of eliding them.
+        strip_internal: tsc's stripInternal; omit `/** @internal */` declarations from the
+            .d.ts outputs.
         **kwargs: common attributes forwarded to the rule.
     """
     out_dir = _clean_dir(out_dir)
@@ -518,5 +529,6 @@ def oxc_transpiler(
         helpers_module = helpers_module or "",
         use_define_for_class_fields = _tristate(use_define_for_class_fields),
         verbatim_module_syntax = verbatim_module_syntax or False,
+        strip_internal = strip_internal or False,
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -772,6 +772,61 @@ diff_test(
     file2 = "importselided/imports.d.ts",
 )
 
+# strip_internal omits `/** @internal */` declarations from the .d.ts outputs,
+# like tsc's stripInternal; the JS output keeps them.
+oxc_transpiler(
+    name = "transpile_internal_kept",
+    srcs = ["src/internal.ts"],
+    emit_dts = True,
+    out_dir = "internalkept",
+    root_dir = "src",
+)
+
+diff_test(
+    name = "internal_kept_dts_test",
+    file1 = "internalkept/internal.d.ts",
+    file2 = "snapshots/internal.d.ts",
+)
+
+oxc_transpiler(
+    name = "transpile_strip_internal",
+    srcs = ["src/internal.ts"],
+    emit_dts = True,
+    out_dir = "stripinternal",
+    root_dir = "src",
+    strip_internal = True,
+)
+
+diff_test(
+    name = "strip_internal_dts_test",
+    file1 = "stripinternal/internal.d.ts",
+    file2 = "snapshots/internal_stripped.d.ts",
+)
+
+diff_test(
+    name = "strip_internal_js_test",
+    file1 = "stripinternal/internal.js",
+    file2 = "internalkept/internal.js",
+)
+
+# strip_internal with emit_js = False: the shape of a ts_project
+# declaration_transpiler, where only the declarations are emitted.
+oxc_transpiler(
+    name = "transpile_strip_internal_dts_only",
+    srcs = ["src/internal.ts"],
+    emit_dts = True,
+    emit_js = False,
+    out_dir = "stripinternaldts",
+    root_dir = "src",
+    strip_internal = True,
+)
+
+diff_test(
+    name = "strip_internal_dts_only_test",
+    file1 = "stripinternaldts/internal.d.ts",
+    file2 = "snapshots/internal_stripped.d.ts",
+)
+
 # module = "commonjs": TypeScript's CommonJS-specific syntax is rewritten (`export =` to
 # module.exports, `import x = require(...)` to a require call) and "use strict" is added. ESM
 # syntax in srcs would be an error: oxc has no ESM-to-CommonJS transform.

--- a/oxc/tests/snapshots/internal.d.ts
+++ b/oxc/tests/snapshots/internal.d.ts
@@ -1,0 +1,21 @@
+/** @internal */
+export declare const secret: number;
+export declare const visible: number;
+/** @internal */
+export declare function helper(): void;
+/** @internal */
+export type Hidden = string;
+/** @internal */
+export declare class Private {}
+export interface Options {
+	/** @internal */
+	debug?: boolean;
+	name: string;
+}
+export declare class Api {
+	/** @internal */
+	hidden(): void;
+	/** @internal */
+	state: number;
+	shown(): void;
+}

--- a/oxc/tests/snapshots/internal_stripped.d.ts
+++ b/oxc/tests/snapshots/internal_stripped.d.ts
@@ -1,0 +1,7 @@
+export declare const visible: number;
+export interface Options {
+	name: string;
+}
+export declare class Api {
+	shown(): void;
+}

--- a/oxc/tests/src/internal.ts
+++ b/oxc/tests/src/internal.ts
@@ -1,0 +1,29 @@
+/** @internal */
+export const secret: number = 1;
+
+export const visible: number = 2;
+
+/** @internal */
+export function helper(): void {}
+
+/** @internal */
+export type Hidden = string;
+
+/** @internal */
+export class Private {}
+
+export interface Options {
+  /** @internal */
+  debug?: boolean;
+  name: string;
+}
+
+export class Api {
+  /** @internal */
+  hidden(): void {}
+
+  /** @internal */
+  state: number = 0;
+
+  shown(): void {}
+}


### PR DESCRIPTION
Expose the transpiler's --strip-internal flag, mirroring tsc's stripInternal: declarations documented with `/** @internal */` are omitted from the .d.ts outputs. Only passed when emitting declarations.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
