### PR TITLE
feat: add jsx_import_source

### DIFF
--- a/e2e/ts_project/README.md
+++ b/e2e/ts_project/README.md
@@ -27,6 +27,8 @@ and `declaration_transpiler` attributes, one configuration per subdirectory:
   `verbatim_module_syntax`, keeping imports unused after type stripping.
 - `strip_internal` - tsconfig `stripInternal` mirrored by `strip_internal`,
   omitting `@internal` declarations from the shared transpile target's `.d.ts`.
+- `jsx_import_source` - tsconfig `jsxImportSource` mirrored by
+  `jsx_import_source` for the automatic runtime.
 
 It lives as a separate e2e workspace because `ts_project` requires the
 `@npm_typescript` repository and node toolchain setup that the aspect_rules_oxc

--- a/e2e/ts_project/jsx_import_source/BUILD
+++ b/e2e/ts_project/jsx_import_source/BUILD
@@ -1,0 +1,58 @@
+"""oxc_transpiler with a custom automatic JSX runtime, matching tsconfig
+jsxImportSource.
+
+The runtime import comes from "preact/jsx-runtime" instead of React's. The
+module's types come from the ambient declaration in src/preact.d.ts here, in
+place of the real package.
+"""
+
+load("@aspect_rules_oxc//oxc:defs.bzl", "oxc_transpiler")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+package(default_testonly = True)
+
+ts_project(
+    name = "ts",
+    srcs = [
+        "src/component.tsx",
+        "src/preact.d.ts",
+    ],
+    declaration = True,
+    out_dir = "dist",
+    root_dir = "src",
+    transpiler = partial.make(
+        oxc_transpiler,
+        jsx_import_source = "preact",
+        out_dir = "dist",
+        root_dir = "src",
+    ),
+    tsconfig = {
+        "compilerOptions": {
+            "jsx": "react-jsx",
+            "jsxImportSource": "preact",
+        },
+    },
+)
+
+build_test(
+    name = "ts_project_test",
+    targets = [
+        ":ts",
+        ":ts_types",
+    ],
+)
+
+diff_test(
+    name = "js_test",
+    file1 = "dist/component.js",
+    file2 = "snapshots/component.js",
+)
+
+diff_test(
+    name = "dts_test",
+    file1 = "dist/component.d.ts",
+    file2 = "snapshots/component.d.ts",
+)

--- a/e2e/ts_project/jsx_import_source/snapshots/component.d.ts
+++ b/e2e/ts_project/jsx_import_source/snapshots/component.d.ts
@@ -1,0 +1,3 @@
+export declare function Component(props: {
+    label: string;
+}): unknown;

--- a/e2e/ts_project/jsx_import_source/snapshots/component.js
+++ b/e2e/ts_project/jsx_import_source/snapshots/component.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "preact/jsx-runtime";
+export function Component(props) {
+	return /* @__PURE__ */ _jsx("span", { children: props.label });
+}

--- a/e2e/ts_project/jsx_import_source/src/component.tsx
+++ b/e2e/ts_project/jsx_import_source/src/component.tsx
@@ -1,0 +1,3 @@
+export function Component(props: { label: string }): unknown {
+  return <span>{props.label}</span>;
+}

--- a/e2e/ts_project/jsx_import_source/src/preact.d.ts
+++ b/e2e/ts_project/jsx_import_source/src/preact.d.ts
@@ -1,0 +1,7 @@
+declare module "preact/jsx-runtime" {
+  export namespace JSX {
+    interface IntrinsicElements {
+      [name: string]: unknown;
+    }
+  }
+}

--- a/oxc/private/oxc_transpiler.bzl
+++ b/oxc/private/oxc_transpiler.bzl
@@ -156,6 +156,8 @@ def _run_transpile(ctx, srcs, js_outs, dts_outs, map_outs):
             args.add("--source-maps")
         if ctx.attr.jsx:
             args.add("--jsx", ctx.attr.jsx)
+        if ctx.attr.jsx_import_source:
+            args.add("--jsx-import-source", ctx.attr.jsx_import_source)
         if ctx.attr.rewrite_extensions:
             args.add("--rewrite-extensions")
         if ctx.attr.target:
@@ -193,6 +195,9 @@ def _oxc_transpiler_impl(ctx):
 
     if ctx.attr.declaration_dir != "" and ctx.attr.root_dir == "":
         fail("When declaration_dir is set, root_dir must also be set.")
+
+    if ctx.attr.jsx_import_source and ctx.attr.jsx == "classic":
+        fail("jsx_import_source requires the automatic JSX runtime; unset it or set jsx = \"automatic\".")
 
     declaration_dir = ctx.attr.declaration_dir or ctx.attr.out_dir
     root_dir = "" if ctx.attr.root_dir == "." else ctx.attr.root_dir
@@ -392,6 +397,11 @@ _oxc_transpiler_rule = rule(
                   "tsc's jsx value spellings to oxc's manually.",
             values = ["", "automatic", "classic"],
         ),
+        "jsx_import_source": attr.string(
+            doc = "Module the automatic JSX runtime is imported from, tsc's " +
+                  "jsxImportSource; \"react\" by default. Only applies to " +
+                  "jsx = \"automatic\".",
+        ),
         "rewrite_extensions": attr.bool(
             default = False,
             doc = "Rewrite import/export specifiers that end in '.ts', '.tsx', " +
@@ -479,6 +489,7 @@ def oxc_transpiler(
         use_define_for_class_fields = None,
         verbatim_module_syntax = False,
         strip_internal = False,
+        jsx_import_source = "",
         **kwargs):
     """Macro wrapping _oxc_transpiler_rule that pre-declares output files at load time.
 
@@ -504,6 +515,8 @@ def oxc_transpiler(
             after type stripping instead of eliding them.
         strip_internal: tsc's stripInternal; omit `/** @internal */` declarations from the
             .d.ts outputs.
+        jsx_import_source: module the automatic JSX runtime is imported from, tsc's
+            jsxImportSource.
         **kwargs: common attributes forwarded to the rule.
     """
     out_dir = _clean_dir(out_dir)
@@ -530,5 +543,6 @@ def oxc_transpiler(
         use_define_for_class_fields = _tristate(use_define_for_class_fields),
         verbatim_module_syntax = verbatim_module_syntax or False,
         strip_internal = strip_internal or False,
+        jsx_import_source = jsx_import_source or "",
         **kwargs
     )

--- a/oxc/tests/BUILD.bazel
+++ b/oxc/tests/BUILD.bazel
@@ -222,6 +222,52 @@ diff_test(
     file2 = "snapshots/component_classic.js",
 )
 
+# jsx_import_source redirects the automatic runtime import from "react" to the
+# given module, like tsc's jsxImportSource, for every runtime import (jsx, jsxs
+# and Fragment) and for plain .jsx sources too; explicit jsx = "automatic" is
+# the same as leaving it unset.
+[
+    (
+        oxc_transpiler(
+            name = "transpile_jsx_import_source_" + name,
+            srcs = [
+                "src/component.tsx",
+                "src/fragment.tsx",
+                "src/widget.jsx",
+            ],
+            emit_dts = True,
+            jsx = jsx,
+            jsx_import_source = "preact",
+            out_dir = "importsource_" + name,
+            root_dir = "src",
+        ),
+        diff_test(
+            name = "jsx_import_source_" + name + "_test",
+            file1 = "importsource_" + name + "/component.js",
+            file2 = "snapshots/component_preact.js",
+        ),
+        diff_test(
+            name = "jsx_import_source_" + name + "_fragment_test",
+            file1 = "importsource_" + name + "/fragment.js",
+            file2 = "snapshots/fragment_preact.js",
+        ),
+        diff_test(
+            name = "jsx_import_source_" + name + "_widget_test",
+            file1 = "importsource_" + name + "/widget.js",
+            file2 = "snapshots/widget_preact.js",
+        ),
+        diff_test(
+            name = "jsx_import_source_" + name + "_dts_test",
+            file1 = "importsource_" + name + "/component.d.ts",
+            file2 = "snapshots/component.d.ts",
+        ),
+    )
+    for name, jsx in [
+        ("default", ""),
+        ("automatic", "automatic"),
+    ]
+]
+
 diff_test(
     name = "dts_component_test",
     file1 = "dist/component.d.ts",

--- a/oxc/tests/snapshots/component_preact.js
+++ b/oxc/tests/snapshots/component_preact.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "preact/jsx-runtime";
+export function Component(props) {
+	return /* @__PURE__ */ _jsx("span", { children: props.label });
+}

--- a/oxc/tests/snapshots/fragment_preact.js
+++ b/oxc/tests/snapshots/fragment_preact.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "preact/jsx-runtime";
+export function Pair(props) {
+	return /* @__PURE__ */ _jsxs(_Fragment, { children: [/* @__PURE__ */ _jsx("span", { children: props.a }), /* @__PURE__ */ _jsx("span", { children: props.b })] });
+}

--- a/oxc/tests/snapshots/widget_preact.js
+++ b/oxc/tests/snapshots/widget_preact.js
@@ -1,0 +1,3 @@
+import { Component } from "./component";
+import { jsx as _jsx } from "preact/jsx-runtime";
+export const widget = /* @__PURE__ */ _jsx(Component, { label: "w" });

--- a/oxc/tests/src/fragment.tsx
+++ b/oxc/tests/src/fragment.tsx
@@ -1,0 +1,8 @@
+export function Pair(props: { a: string; b: string }): unknown {
+  return (
+    <>
+      <span>{props.a}</span>
+      <span>{props.b}</span>
+    </>
+  );
+}


### PR DESCRIPTION
Expose the transpiler's --jsx-import-source flag, mirroring tsc's jsxImportSource for the automatic runtime. Setting it with jsx = "classic" is an analysis error rather than a tool error.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
