### PR TITLE
chore: update bcr presubmit to use modern bazel+os

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,8 +1,8 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
-    bazel: ["7.x", "6.x"]
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["8.x", "9.x"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
